### PR TITLE
syntax/v.vim: various changes

### DIFF
--- a/syntax/v.vim
+++ b/syntax/v.vim
@@ -17,6 +17,7 @@ syn keyword VReserve
   \ module import
   \ interface type
   \ const mut pub
+  \ none
 syn keyword VBuiltIn
   \ assert
   \ print println
@@ -32,10 +33,9 @@ syn keyword VType
   \ char
   \ string
   \ byteptr voidptr
-  \ none
 
 syn match  VOperator "[-+!|&<>=%*/^:;.,]" skipwhite
-syn match  VFunction '\w\+\s*('me=e-1,he=e-1
+syn match  VFunction '\w\+\_s\{-}('me=e-1,he=e-1
 syn match  VClass    '\u\w\+'
 
 syn region VComment     start='/\*' end='\*/'
@@ -50,13 +50,19 @@ syn region  VString              start="'" end="'" contains=VStringVariable,VStr
 syn region  VStringRaw           start="r'" end="'" contains=VStringVariable,VStringInterpolation
 syn region  VStringInterpolation start='${' end='}'
 syn match   VStringVariable      '\$\w\+'
+syn match   VPreProcVariable     '@\(FN\|MOD\|STRUCT\|FILE\|LINE\|COLUMN\|VEXE\|VHASH\|VMOD_FILE\)'
 
-hi def link VCondition Conditional
-hi def link VLoop      Repeat
-hi def link VState     Conditional
-hi def link VReserve   Keyword
-hi def link VBuiltIn   Constant
-hi def link VLibrary   Constant
+syn match VBrackets    "[][}{]"
+syn match VParentheses "[)(]"
+
+hi def link VCondition       Conditional
+hi def link VLoop            Repeat
+hi def link VState           Conditional
+hi def link VReserve         Keyword
+hi def link VBuiltIn         Constant
+hi def link VLibrary         Constant
+hi def link VEscapeSymbol    Character
+hi def link VPreProcVariable PreProc
 
 hi def link VStruct   Structure
 hi def link VType     Type
@@ -66,6 +72,8 @@ hi def link VFunction    Function
 hi def link VClass       Function
 hi def link VComment     Comment
 hi def link VCommentLine Comment
+hi def link VBrackets    Delimiter
+hi def link VParentheses Delimiter
 
 hi def link VBoolean             Boolean
 hi def link VInteger             Number


### PR DESCRIPTION
- move "none" to VReserve because it's a keyword (accorging to docs)
- match function even if open parenthesis is not in the same line
- match preprocess variables
- match square and round brackets